### PR TITLE
Add env Configuration for JSON Comparator  Settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,5 +3,5 @@ CHAIN_ID=300
 ZKSYNC_SEPOLIA_PRIVATE_KEY=your_private_key_here
 FINGERPRINT_PROXY_SC=your_contract_address_here
 
-SIMILARITY_THRESHOLD =similarity threshold as a float
-NUM_HASH_FUNCTIONS =number of hash functions used in the MinHash
+SIMILARITY_THRESHOLD=similarity threshold as a float
+NUM_HASH_FUNCTIONS=number of hash functions used in the MinHash

--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,6 @@ ZKSYNC_URL=https://sepolia.era.zksync.dev
 CHAIN_ID=300
 ZKSYNC_SEPOLIA_PRIVATE_KEY=your_private_key_here
 FINGERPRINT_PROXY_SC=your_contract_address_here
+
+SIMILARITY_THRESHOLD =similarity threshold as a float
+NUM_HASH_FUNCTIONS =number of hash functions used in the MinHash

--- a/modules/coordination_module/json_comparator/src/lib.rs
+++ b/modules/coordination_module/json_comparator/src/lib.rs
@@ -1,4 +1,5 @@
 use colored::*;
+use std::env;
 
 #[macro_use]
 pub mod data;
@@ -14,11 +15,14 @@ use hash::minhash_comparison::{calculate_similarities, find_best_similarity};
 /// # Returns
 /// - `Option<String>`: The JSON string with the highest similarity, if any.
 pub fn run_json_comparator(json_objects: &[String]) -> Option<String> {
-    let similarity_threshold = 0.72;
-    println!("\nSimilarity Threshold: {}%", format!("{:.1}", similarity_threshold * 100.0).blue());
-
-    let num_hash_functions = 100;
-    println!("Number of Hash Functions: {}\n", num_hash_functions.to_string().blue());
+    let similarity_threshold: f64 = env::var("SIMILARITY_THRESHOLD")
+        .unwrap_or_else(|_| "0.72".to_string())
+        .parse()
+        .unwrap_or(0.0);
+    let num_hash_functions: usize = env::var("NUM_HASH_FUNCTIONS")
+        .unwrap_or_else(|_| "100".to_string())
+        .parse()
+        .unwrap_or(0);
 
     let json_strs: Vec<&str> = json_objects.iter().map(|s| s.as_str()).collect();
 


### PR DESCRIPTION
[PFI-149](https://playfi-labs.atlassian.net/browse/PFI-149)

**Description:**
This PR introduces environment variable configuration for the JSON comparator settings by utilising a `.env` file. The changes include the addition of new environment variables for `SIMILARITY_THRESHOLD` and `NUM_HASH_FUNCTIONS` in the JSON comparator.

These modifications improve the flexibility and configurability of the application, making it easier to manage environment-specific settings and reducing the need for hardcoded values in the codebase.

**Tasks:**

1. Refactored `.env.example`:

- [x] Added placeholders for `SIMILARITY_THRESHOLD` and `NUM_HASH_FUNCTIONS` with corresponding explanations.

2. Updated lib.rs:

- [x] Implemented the loading of `SIMILARITY_THRESHOLD` and `NUM_HASH_FUNCTIONS` from the environment variables using `std::env` and `dotenv`.

3. Added `dotenv` to dependencies:

- [x] Ensured the `dotenv` crate is included in the `Cargo.toml` to support loading environment variables.


**Additional Notes:**

Ensure to fill in the correct values for `SIMILARITY_THRESHOLD` and `NUM_HASH_FUNCTIONS` in the .env file in your local environment.
These changes are backward-compatible and provide a more configurable approach to managing important application settings.


[PFI-149]: https://playfi-labs.atlassian.net/browse/PFI-149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ